### PR TITLE
Matching GF repo structure

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,9 @@
+# This is the official list of project authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS.txt file.
+# See the latter for an explanation.
+#
+# Names should be added to this file as:
+# Name or Organization <email address
+
+Intel Corp. <brand_q@intel.com>
+Frere-Jones Type <info@frerejones.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -7,7 +7,7 @@
 # name or J's organization's name should be added to `AUTHORS.txt`
 #
 # Names should be added to this file as:
-# Name <email address
+# Name <email address>
 
 Matthew Turrini
 Fred Shallcrass

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,15 @@
+# This is the list of people who have contributed to this project,
+# and includes those not listed in `AUTHORS.txt` because they are not
+# copyright authors. For example, company employees may be listed
+# here because their company holds the copyright and is listed there.
+#
+# When adding J Random Contributor's name to this file, either J's
+# name or J's organization's name should be added to `AUTHORS.txt`
+#
+# Names should be added to this file as:
+# Name <email address
+
+Matthew Turrini
+Fred Shallcrass
+Nina Stössinger
+Tobias Frere-Jones

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,8 +1,8 @@
-Copyright (c) 2023 Intel Corp. with Reserved Font Name "Intel One Mono", "IntelOne Mono"
+Copyright 2023 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name "Intel One Mono", "IntelOne Mono"
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
-
-This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
 
 
 -----------------------------------------------------------

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2023 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name "Intel One Mono", "IntelOne Mono"
+Copyright 2023 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name 'Intel One Mono', 'IntelOne Mono'
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
@MatthewTurrini 

I Added the txt files to match [GF repo structure](https://googlefonts.github.io/gf-guide/upstream.html)
I filled up the AUTHORS.txt and CONTRIBUTORS.txt but it probably need correction/completion. 

Anyone who contributes to this repo/project should be credited in CONTRIBUTORS.txt, and all the authors listed in AUTHORS.txt will be credited in the About section of the specimen page. You can choose to credit as authors all participating designers, or only the involved compagnies, or the only legal copyright holder. (Eg. https://fonts.google.com/specimen/Kablammo/about)

According to what you choose; you can send us the bios through this form: https://docs.google.com/forms/d/e/1FAIpQLSeMwHN8J213ZaxHrr5lHCrX56HY_NjGrWB8o604g98YxuMrdA/viewform