### PR TITLE
Update README with updated font title

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Intel One Mono also covers a wide range of over 200 languages using the Latin sc
 To install the fonts, please use the provided builds under [Releases](https://github.com/intel/intel-one-mono/releases). Please refer to your software’s documentation for how to activate and use these fonts.
 
 ### Activating the Fonts in Code Editors
-- VSCode - In Settings, search Font Family, then specify `IntelOne Mono`
-- Sublime Text - Go to Sublime Text -> Preferences -> Settings and set `font_face` to `IntelOne Mono`
-- IntelliJ Platform - Go to File -> Settings -> Editor -> Font and set Font to `IntelOne Mono`
+- VSCode - In Settings, search Font Family, then specify `Intel One Mono`
+- Sublime Text - Go to Sublime Text -> Preferences -> Settings and set `font_face` to `Intel One Mono`
+- IntelliJ Platform - Go to File -> Settings -> Editor -> Font and set Font to `Intel One Mono`
 
 ### Font Formats
 - We recommend the .otf or .ttf format for desktop use.


### PR DESCRIPTION
With the updated release of V1.3.0, the font title is changed from `IntelOne Mono` to `Intel One Mono`. This PR updates the title in the README accordingly. 